### PR TITLE
Decycle metadata

### DIFF
--- a/lib/joke.js
+++ b/lib/joke.js
@@ -1,5 +1,6 @@
 var util = require('util');
 var Readable = require('stream').Readable;
+var cycle = require('cycle');
 var Stringify = require('./stringify');
 var LogMessage = require('./log-message.js');
 
@@ -37,6 +38,7 @@ Joke.prototype._buildLevels = function () {
 
 Joke.prototype.log = function (level, msg, data) {
   var l = this._levels[level];
+  var decycled = cycle.decycle(data);
   if (!l) {
     throw new Error('Invalid log level: ' + level);
   }

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
   },
   "scripts": {
     "test": "node test/simple-test.js && node bench/bench.js"
+  },
+  "dependencies": {
+    "cycle": "~1.0.3"
   }
 }


### PR DESCRIPTION
Fixes #2.

cc @marcusbesjes

This is a WIP - `decycle` method is still too slow to be viable for use in a logger.
